### PR TITLE
Fix infinite scroll

### DIFF
--- a/src/summaries/components/Summaries.js
+++ b/src/summaries/components/Summaries.js
@@ -10,6 +10,7 @@ import { summariesSelector } from '../selectors'
 export class Summaries extends Component {
   constructor(props) {
     super(props)
+    this.hasScrollEventAttached = false
     this.handleScroll = _.debounce(this.handleScroll.bind(this), 150)
   }
 
@@ -39,12 +40,30 @@ export class Summaries extends Component {
   }
 
   componentDidMount () {
+    this.hasScrollEventAttached = true
     window.addEventListener('scroll', this.handleScroll)
     this.props.fetchSummaries()
   }
 
   componentWillUnmount () {
     window.removeEventListener('scroll', this.handleScroll)
+    this.hasScrollEventAttached = false
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (
+      this.hasScrollEventAttached &&
+      this.props.status === 'fetching' &&
+      nextProps.status === 'failure'
+    ) {
+      window.removeEventListener('scroll', this.handleScroll)
+      this.hasScrollEventAttached = false
+    }
+
+    if (!this.hasScrollEventAttached && nextProps.status === 'success') {
+      this.hasScrollEventAttached = true
+      window.addEventListener('scroll', this.handleScroll)
+    }
   }
 
   render () {
@@ -63,7 +82,7 @@ export class Summaries extends Component {
               </Alert>
               <button
                 className="btn btn-outline-primary btn-sm"
-                onClick={this.props.fetchSummaries()}
+                onClick={this.props.fetchSummaries}
               >
                 Volver a intentar
               </button>

--- a/src/summaries/components/__tests__/__snapshots__/Summaries.js.snap
+++ b/src/summaries/components/__tests__/__snapshots__/Summaries.js.snap
@@ -20,7 +20,7 @@ exports[`Summaries renders error 1`] = `
     </div>
     <button
       className="btn btn-outline-primary btn-sm"
-      onClick={undefined}
+      onClick={[Function]}
     >
       Volver a intentar
     </button>


### PR DESCRIPTION
El componente summaries contiene dos bugs:
1. el botón para reintentar cargar más summaries, en su evento on Click
  se ha proporcinado un objecto generado por la acción y no la acción en
  sí. Esto se debe al uso de paréntesis.
2. el evento scroll sigue evaluando la posición aún si hay un error por
  lo que sigue intentando recargar más summaries y no permite ver el
  mensaje de error ni pulsar el botón reintentar.

Para corregir los errores se hicieron los siguientes cambios:

- Corregir el typo en el botón reintentar (remover paréntesis).

- Agregar dos condiciones dentro de componentWillReceiveProps. La
  primera permite remover el evento scroll cuando hay un error al
  solicitar summaries. De esta manera ya no se realizan recargas hasta
  que se pulse el botón reintentar.
  La segunda condición agrega el evento scroll nuevamente cuando se
  pulsa el botón reintentar y este es exitoso. Así se puede volver a
  usar el scroll infino después de algún error de red u otros.