### PR TITLE
Corregir estilos de comentarios

### DIFF
--- a/src/comments/components/Comment.css
+++ b/src/comments/components/Comment.css
@@ -1,5 +1,5 @@
 .Comment:last-child {
-  margin-bottom: 0 !important; 
+  margin-bottom: 0 !important;
 }
 
 .Comment-avatar {
@@ -14,4 +14,17 @@
   font-size: .85rem;
   font-weight: normal;
   margin-left: 10px;
+}
+
+.Comment-body img {
+  max-width: 100%;
+}
+
+.Comment-body {
+  word-break: break-all;
+}
+
+.Comment-body span[style^='position:relative'] {
+  overflow: hidden;
+  height: 16px;
 }


### PR DESCRIPTION
Existen tres bugs en el cuerpo de los comentarios:

1) Las imágenes se sobresalen si tienen un ancho mayor al div del
   comentario.

2) El texto se sobresale si una línea es mayou al div del comentario.

3) El sprite de los íconos tiene un alto completo sin importar que se
   muestre uno solo lo que causa que se genere un espacio entre el
   contenido y el viewport.

Para corregir estos errores se implementa los siguientes cambios:

- Agregar max-width: 100% a las imagenes dentro del cuerpo del
  comentario.

- Agregar word-break: break-all para mantener el texto dentro del
  comentario.

- Agregar overflow: hidden y height: 16px para ocultar el resto del
  sprite de los íconos.