### PR TITLE
Fix: Recarga de summaries al navegar entre páginas

### DIFF
--- a/src/summaries/__tests__/actions.js
+++ b/src/summaries/__tests__/actions.js
@@ -6,6 +6,10 @@ import thunk from 'redux-thunk'
 import * as types from '../types'
 import * as actions from '../actions'
 
+const middlewares = [thunk.withExtraArgument(axios)]
+const mockStore = configureMockStore(middlewares)
+const mock = new MockAdapter(axios)
+
 describe('Summaries actions', () => {
   it('creates an action to start fetching summaries', () => {
     expect(actions.fetchRequest()).toEqual({
@@ -27,15 +31,24 @@ describe('Summaries actions', () => {
   })
 })
 
+describe('Invalidates', () => {
+  it('creates an action to invalidate', () => {
+    const store = mockStore({})
+
+    return store.dispatch(actions.invalidate()).then(() => {
+      expect(store.getActions()).toEqual([
+        { type: types.INVALIDATE },
+      ])
+    })
+
+  })
+})
+
 describe('Fetch summaries async action', () => {
   const data = [
     { id: 1, foo: 'foo'},
     { id: 2, foo: 'foo'},
   ]
-
-  const middlewares = [thunk.withExtraArgument(axios)]
-  const mockStore = configureMockStore(middlewares)
-  const mock = new MockAdapter(axios)
 
   afterEach(() => mock.reset())
 

--- a/src/summaries/__tests__/reducers.js
+++ b/src/summaries/__tests__/reducers.js
@@ -26,6 +26,19 @@ describe('Summaries entities reducer', () => {
       2: { bar: false, foo: true, id: 2 },
     })
   })
+
+  it('handles INVALIDATE', () => {
+    const action = {
+      type: types.INVALIDATE
+    }
+
+    const state = {
+      1: { bar: false, foo: true, id: 1 },
+      2: { bar: false, foo: true, id: 2 },
+    }
+
+    expect(summariesEntities(state, action)).toEqual({})
+  })
 })
 
 describe('Summaries fetch control reducer', () => {
@@ -93,6 +106,30 @@ describe('Summaries fetch control reducer', () => {
       error: 'Network Error',
       ids: [],
       status: 'failure',
+    })
+  })
+
+  it('handles INVALIDATE', () => {
+    const action = {
+      type: types.INVALIDATE
+    }
+
+    const state = {
+      after: 30,
+      before: 32,
+      error: 'Network Error',
+      ids: [1, 2, 3, 4, 5],
+      status: 'failure',
+      totalCount: 500,
+    }
+
+    expect(summariesFetchControl(state, action)).toEqual({
+      after: null,
+      before: null,
+      error: '',
+      ids: [],
+      status: 'success',
+      totalCount: 0,
     })
   })
 })

--- a/src/summaries/actions.js
+++ b/src/summaries/actions.js
@@ -17,6 +17,13 @@ export const fetchFailure = message => ({
   message: message,
 })
 
+export const invalidate = () => {
+  return (dispatch) => {
+    dispatch({ type: types.INVALIDATE })
+    return Promise.resolve()
+  }
+}
+
 const canFetch = state => {
   return state.control.summariesFetch.status !== 'fetching'
 }

--- a/src/summaries/actions.js
+++ b/src/summaries/actions.js
@@ -18,7 +18,7 @@ export const fetchFailure = message => ({
 })
 
 export const invalidate = () => {
-  return (dispatch) => {
+  return dispatch => {
     dispatch({ type: types.INVALIDATE })
     return Promise.resolve()
   }

--- a/src/summaries/components/Summaries.js
+++ b/src/summaries/components/Summaries.js
@@ -42,7 +42,7 @@ export class Summaries extends Component {
   componentDidMount () {
     this.hasScrollEventAttached = true
     window.addEventListener('scroll', this.handleScroll)
-    this.props.fetchSummaries()
+    this.props.invalidate().then(() => this.props.fetchSummaries())
   }
 
   componentWillUnmount () {
@@ -104,6 +104,7 @@ export class Summaries extends Component {
 
 Summaries.defaultProps = {
   fetchSummaries: () => {},
+  invalidate: () => Promise.resolve(),
   status: "success",
   summaries: [],
 }
@@ -115,7 +116,8 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  fetchSummaries: () => dispatch(actions.fetch())
+  fetchSummaries: () => dispatch(actions.fetch()),
+  invalidate: () => dispatch(actions.invalidate()),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Summaries)

--- a/src/summaries/components/__tests__/Summaries.js
+++ b/src/summaries/components/__tests__/Summaries.js
@@ -39,11 +39,16 @@ describe('Summaries', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('fetches summaries on mount', () => {
-    const mock = jest.fn()
+  it('fetches summaries on mount', async () => {
+    const promise = Promise.resolve()
+    const mock = jest.fn(() => promise)
+    const mockFetch = jest.fn()
 
-    mount(<Summaries fetchSummaries={mock}/>)
+    mount(<Summaries invalidate={mock} fetchSummaries={mockFetch} />)
+
+    await promise
 
     expect(mock).toBeCalled()
+    expect(mockFetch).toBeCalled()
   })
 })

--- a/src/summaries/reducers.js
+++ b/src/summaries/reducers.js
@@ -2,11 +2,16 @@ import _ from 'lodash'
 import * as types from './types'
 
 export const summariesEntities = (state = {}, action) => {
-  if (action.entities && action.entities.summaries) {
-    return _.merge({}, state, action.entities.summaries)
-  }
+  switch (action.type) {
+    case types.INVALIDATE:
+      return {}
+    default:
+      if (action.entities && action.entities.summaries) {
+        return _.merge({}, state, action.entities.summaries)
+      }
 
-  return state
+      return state
+  }
 }
 
 const fetchControlInitialState = {
@@ -35,6 +40,8 @@ export const summariesFetchControl = (
       })
     case types.FETCH_FAILURE:
       return _.assign({}, state, { status: 'failure', error: action.message })
+    case types.INVALIDATE:
+      return fetchControlInitialState
     default:
       return state
   }

--- a/src/summaries/types.js
+++ b/src/summaries/types.js
@@ -1,3 +1,5 @@
 export const FETCH_REQUEST = 'summaries/FETCH_REQUEST'
 export const FETCH_SUCCESS = 'summaries/FETCH_SUCCESS'
 export const FETCH_FAILURE = 'summaries/FETCH_FAILURE'
+
+export const INVALIDATE = 'summaries/INVALIDATE'


### PR DESCRIPTION
Cuando se navega desde la página Story a index, automáticamente se
realiza una carga de summaries. Y No se elimina la existente, creando
nuevas entradas sin que el usuario haga scroll hasta el final de la
página.

Para corregir este comportamiento se implementan los siguientes cambios:

- Agregar una nueva acción para invalidar los summaries ya existentes.

- Al momento de navegar a index; cuando el componente se monta primero
  se invalida los summaries existentes y luego se descarga la página
  nuevamente.

Estas correcciones aseguran que solo el scroll una vez al final de la
página descargue más summaries y no navegar entre páginas.