### PR TITLE
Fix: iframe overflow

### DIFF
--- a/src/comments/components/Comment.css
+++ b/src/comments/components/Comment.css
@@ -20,6 +20,10 @@
   max-width: 100%;
 }
 
+.Comment iframe {
+  max-width: 100%;
+}
+
 .Comment-body {
   word-break: break-word;
 }


### PR DESCRIPTION
El elemento iframe causa que el contenido del comentario se desborde.